### PR TITLE
Use babel-plugin-react-intl-auto

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Use riw to:
 
 - Define target locales for your app: the locales into which you translate the app.
 - Extract `react-intl` message descriptors from your React components, directly or indirectly.
-- Check for duplicates in your `react-intl` message descriptor ids.
+- Check for duplicates in your `react-intl` message descriptor ids if you need to.
 - Manage translations for each target locale, storing them in a simple translations database.
 - Generate JSON files for your translations, to include in your app.
 
@@ -32,7 +32,7 @@ riw assumes you're familiar with `react-intl`, and that your app already uses a 
 
 - riw doesn't perform any automated text translation or interface with any translators or translation services. It tells you which messages need translating, lets you update its translations database with the translations once you have them, and produces shippable, `react-intl`-compatible JSON files for each locale you want to support.
 
-- riw doesn't provide a mechanism for generating unique `react-intl` message descriptor ids. How you define these depends on your app's requirements. However, it does let you identify any duplicate ids. ([See the FAQ](doc/faq.md) for a possible naming scheme to help avoid duplicates.)
+- riw doesn't provide its own mechanism for generating unique `react-intl` message descriptor ids. However, by default riw uses `babel-plugin-react-intl-auto` to autogenerate ids. ([See the FAQ](doc/faq.md) and https://github.com/akameco/babel-plugin-react-intl-auto for more.)
 
 - riw doesn't import the generated JSON locale files into your app or plug them into `react-intl`'s `IntlProvider`. You implement this behaviour yourself.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ See [Introducing riw](https://medium.com/@avaragado/introducing-riw-854f9a2c9f52
 
 <img src="doc/assets/riw-app-status.png" width="600">
 
-There's an example repository, [`riw-example`](https://github.com/avaragado/riw-example), showing (in its commit history) how to migrate a simple React app with hard-coded strings to `react-intl`, and then how to use riw with it.
+There's an example repository, [`riw-example`](https://github.com/avaragado/riw-example), showing a simple internationalised React app set up for use with riw.
 
 The word "riw" seems to be Welsh for _slope_ or _hill_, and rhymes with the English word _drew_.
 

--- a/doc/config.md
+++ b/doc/config.md
@@ -74,8 +74,22 @@ When `inputMode` is `json`, riw collates these JSON files for translation and do
 
 How riw should locate the `react-intl` message descriptors to translate.
 
-- Use `source` and set `sourceDirs` if you want riw to extract message descriptors from your source files using `babel-plugin-react-intl`.
+- Use `source` and set `sourceDirs` if you want riw to extract message descriptors from your source files using `babel-plugin-react-intl` and `babel-plugin-react-intl-auto`.
 - Use `json` and set `collateDir` if you want riw to use message descriptors already extracted from your source files by another process, for example webpack.
+
+
+### `reactIntlAutoConfig`
+
+- Type: `false` | `Object`
+- Default value: `{ removePrefix: 'src', filebase: true }`
+
+The configuration object for the `babel-plugin-react-intl-auto` plugin, if you want to use it.
+
+- Use `false` to disable this plugin. With this setting, your message descriptors must be full `react-intl` descriptors with `id`, `defaultMessage` and optional `description` properties.
+- Use an object to define the configuration for `babel-plugin-react-intl-auto`. See https://github.com/akameco/babel-plugin-react-intl-auto. With this plugin enabled, you don't need to worry about generating message descriptor ids yourself.
+
+When `inputMode` is `json`, this setting is ignored.
+
 
 ### `translationsOutputFile`
 

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -42,7 +42,9 @@ If there is any chance of ambiguity, add a description.
 
 ## Can I use objects as descriptions in message descriptors, as `react-intl` allows this?
 
-Yes. You can use either strings or arbitrary objects as the value of the optional `description` property in your message descriptors.
+Yes, if you disable `babel-plugin-react-intl-auto` (set `reactIntlAutoConfig: false` in your configuration). When this plugin is enabled (the default setting) then a message descriptor's description is set to any comment that immediately precedes the string definition. See https://github.com/akameco/babel-plugin-react-intl-auto for more information.
+
+With `babel-plugin-react-intl-auto` disabled, you can use either strings or arbitrary objects as the value of the optional `description` property in your message descriptors.
 
 Description objects are included unchanged in the TODO file riw generates for messages requiring translation. `riw db import` accepts description objects in the input files.
 
@@ -59,6 +61,10 @@ $ riw db list --description 'JSON:{"another_prop":123,"my_prop":"foo"}' # same a
 
 
 ## How do I ensure message descriptor ids are unique?
+
+You don't need to worry about this unless you disable `babel-plugin-react-intl-auto`. With the default configuration, this plugin generates unique message descriptor ids automatically.
+
+Read on if you disable the plugin...
 
 Each `react-intl` message descriptor must include an id that uniquely identifies the message within your app. It uses this id to identify which string to display. However, `react-intl` does not impose or recommend any naming scheme for ids. riw helps by pointing out, as part of the output of `riw app translate`, if you've used the same id more than once.
 

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -39,7 +39,7 @@ Importantly, riw fits into your current development process and does not constra
 
 ## Using riw
 
-If you enjoy scrolling through diffs, the [riw-example](https://github.com/avaragado/riw-example) repository shows how to take a simple React app with hardcoded strings, internationalise it with `react-intl`, and then use it with riw.
+The [riw-example](https://github.com/avaragado/riw-example) repository shows a simple React app, internationalised with `react-intl` and `babel-plugin-react-intl-auto`, set up for use with riw.
 
 Meanwhile, here's the view from 10,000 feet:
 

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   "dependencies": {
     "babel-core": "^6.24.1",
     "babel-plugin-react-intl": "^2.3.1",
+    "babel-plugin-react-intl-auto": "^1.0.0",
     "babel-polyfill": "^6.23.0",
     "babel-runtime": "^6.23.0",
     "bardot": "^0.2.1",

--- a/src/lib/config/index.js
+++ b/src/lib/config/index.js
@@ -10,6 +10,9 @@ import configResolve from './resolve';
 export type InputMode = 'source' | 'json';
 export type OutputMode = 'single-file' | 'file-per-locale' | 'no-file';
 
+// babel-plugin-react-intl-auto configuration object, or false to disable
+type ReactIntlAutoConfig = false | Object;
+
 export type ConfigSparse = {
     defaultLocale?: LocaleId,
     targetLocales?: LocaleId[],
@@ -17,6 +20,7 @@ export type ConfigSparse = {
     sourceDirs?: Glob[],
     collateDir?: Path,
     inputMode?: InputMode,
+    reactIntlAutoConfig?: ReactIntlAutoConfig,
     translationsOutputFile?: Path,
     outputMode?: OutputMode,
     todoFile?: Path,
@@ -38,6 +42,7 @@ export type Config = {
     sourceDirs: Glob[],
     collateDir: Path,
     inputMode: InputMode,
+    reactIntlAutoConfig: ReactIntlAutoConfig,
     translationsOutputFile: Path,
     outputMode: OutputMode,
     todoFile: Path,

--- a/src/lib/config/resolve/__tests__/__snapshots__/index.test.js.snap
+++ b/src/lib/config/resolve/__tests__/__snapshots__/index.test.js.snap
@@ -7,8 +7,8 @@ Object {
   "inputMode": "source",
   "outputMode": "file-per-locale",
   "reactIntlAutoConfig": Object {
-    "filebase": false,
-    "removePrefix": "src/",
+    "filebase": true,
+    "removePrefix": "src",
   },
   "rootDir": ".",
   "sourceDirs": Array [
@@ -29,8 +29,8 @@ Object {
   "inputMode": "source",
   "outputMode": "file-per-locale",
   "reactIntlAutoConfig": Object {
-    "filebase": false,
-    "removePrefix": "src/",
+    "filebase": true,
+    "removePrefix": "src",
   },
   "rootDir": "/foo/bar",
   "sourceDirs": Array [
@@ -50,8 +50,8 @@ Object {
   "inputMode": "source",
   "outputMode": "file-per-locale",
   "reactIntlAutoConfig": Object {
-    "filebase": false,
-    "removePrefix": "src/",
+    "filebase": true,
+    "removePrefix": "src",
   },
   "rootDir": "/foo/bar",
   "sourceDirs": Array [
@@ -72,8 +72,8 @@ Object {
   "inputMode": "source",
   "outputMode": "file-per-locale",
   "reactIntlAutoConfig": Object {
-    "filebase": false,
-    "removePrefix": "src/",
+    "filebase": true,
+    "removePrefix": "src",
   },
   "rootDir": "/foo/bar",
   "sourceDirs": Array [

--- a/src/lib/config/resolve/__tests__/__snapshots__/index.test.js.snap
+++ b/src/lib/config/resolve/__tests__/__snapshots__/index.test.js.snap
@@ -6,6 +6,10 @@ Object {
   "defaultLocale": "en-US",
   "inputMode": "source",
   "outputMode": "file-per-locale",
+  "reactIntlAutoConfig": Object {
+    "filebase": false,
+    "removePrefix": "src/",
+  },
   "rootDir": ".",
   "sourceDirs": Array [
     "src/**/*.js",
@@ -24,6 +28,10 @@ Object {
   "defaultLocale": "en-US",
   "inputMode": "source",
   "outputMode": "file-per-locale",
+  "reactIntlAutoConfig": Object {
+    "filebase": false,
+    "removePrefix": "src/",
+  },
   "rootDir": "/foo/bar",
   "sourceDirs": Array [
     "src/**/*.js",
@@ -41,6 +49,10 @@ Object {
   "defaultLocale": "en-US",
   "inputMode": "source",
   "outputMode": "file-per-locale",
+  "reactIntlAutoConfig": Object {
+    "filebase": false,
+    "removePrefix": "src/",
+  },
   "rootDir": "/foo/bar",
   "sourceDirs": Array [
     "src/**/*.js",
@@ -59,6 +71,10 @@ Object {
   "defaultLocale": "en-US",
   "inputMode": "source",
   "outputMode": "file-per-locale",
+  "reactIntlAutoConfig": Object {
+    "filebase": false,
+    "removePrefix": "src/",
+  },
   "rootDir": "/foo/bar",
   "sourceDirs": Array [
     "src/**/*.js",

--- a/src/lib/config/resolve/configDefault.js
+++ b/src/lib/config/resolve/configDefault.js
@@ -11,7 +11,7 @@ export default ({
     collateDir: 'tmp/babel-plugin-react-intl',
     inputMode: 'source',
     reactIntlAutoConfig: {
-        removePrefix: 'src/',
+        removePrefix: 'src',
         filebase: true,
     },
     translationsOutputFile: 'src/locale/[locale].json',

--- a/src/lib/config/resolve/configDefault.js
+++ b/src/lib/config/resolve/configDefault.js
@@ -10,6 +10,10 @@ export default ({
     sourceDirs: ['src/**/*.js'],
     collateDir: 'tmp/babel-plugin-react-intl',
     inputMode: 'source',
+    reactIntlAutoConfig: {
+        removePrefix: 'src/',
+        filebase: false,
+    },
     translationsOutputFile: 'src/locale/[locale].json',
     outputMode: 'file-per-locale',
     todoFile: 'src/locale/TODO-untranslated.json',

--- a/src/lib/config/resolve/configDefault.js
+++ b/src/lib/config/resolve/configDefault.js
@@ -12,7 +12,7 @@ export default ({
     inputMode: 'source',
     reactIntlAutoConfig: {
         removePrefix: 'src/',
-        filebase: false,
+        filebase: true,
     },
     translationsOutputFile: 'src/locale/[locale].json',
     outputMode: 'file-per-locale',

--- a/src/lib/riw/app/translate/__tests__/__snapshots__/extract.source.test.js.snap
+++ b/src/lib/riw/app/translate/__tests__/__snapshots__/extract.source.test.js.snap
@@ -76,3 +76,67 @@ Array [
   },
 ]
 `;
+
+exports[`lib/riw/app/translate/extract.source 05 1`] = `
+Array [
+  Object {
+    "defaultMessage": "a.1!",
+    "description": undefined,
+    "file": "/fixtures/05/a.js",
+    "id": "a1",
+  },
+  Object {
+    "defaultMessage": "b.1!",
+    "description": undefined,
+    "file": "/fixtures/05/b.js",
+    "id": "b1",
+  },
+  Object {
+    "defaultMessage": "b.2!",
+    "description": "b.2 desc",
+    "file": "/fixtures/05/b.js",
+    "id": "b2",
+  },
+]
+`;
+
+exports[`lib/riw/app/translate/extract.source 06 1`] = `
+Array [
+  Object {
+    "defaultMessage": "a.1!",
+    "description": undefined,
+    "file": "/fixtures/06/a.js",
+    "id": "a1",
+  },
+  Object {
+    "defaultMessage": "a.1 again!",
+    "description": undefined,
+    "file": "/fixtures/06/aa.js",
+    "id": "a1again",
+  },
+  Object {
+    "defaultMessage": "b.1!",
+    "description": undefined,
+    "file": "/fixtures/06/b.js",
+    "id": "b1",
+  },
+  Object {
+    "defaultMessage": "b.2!",
+    "description": "b.2 desc",
+    "file": "/fixtures/06/b.js",
+    "id": "b2",
+  },
+  Object {
+    "defaultMessage": "b.2 again!",
+    "description": "b.2 again desc",
+    "file": "/fixtures/06/bb.js",
+    "id": "b2again",
+  },
+  Object {
+    "defaultMessage": "c.1!",
+    "description": undefined,
+    "file": "/fixtures/06/c.js",
+    "id": "c1",
+  },
+]
+`;

--- a/src/lib/riw/app/translate/__tests__/extract.source.test.js
+++ b/src/lib/riw/app/translate/__tests__/extract.source.test.js
@@ -67,6 +67,9 @@ const fixtures: Fixture[] = [
                 });
             `,
         },
+        configOverride: {
+            reactIntlAutoConfig: false,
+        },
     },
 
     {
@@ -126,6 +129,74 @@ const fixtures: Fixture[] = [
                         id: 'c.1',
                         defaultMessage: 'c.1!',
                     },
+                });
+            `,
+        },
+        configOverride: {
+            reactIntlAutoConfig: false,
+        },
+    },
+    {
+        name: '05',
+        in: {
+            'a.js': outdent`
+                import { defineMessages } from 'react-intl';
+
+                const msg = defineMessages({
+                    a1: 'a.1!',
+                });
+            `,
+            'b.js': outdent`
+                import { defineMessages } from 'react-intl';
+
+                const msg = defineMessages({
+                    b1: 'b.1!',
+                    // b.2 desc
+                    b2: 'b.2!',
+                });
+            `,
+        },
+    },
+
+    {
+        name: '06',
+        in: {
+            'a.js': outdent`
+                import { defineMessages } from 'react-intl';
+
+                const msg = defineMessages({
+                    a1: 'a.1!',
+                });
+            `,
+            'aa.js': outdent`
+                import { defineMessages } from 'react-intl';
+
+                const msg = defineMessages({
+                    a1again: 'a.1 again!',
+                });
+            `,
+            'b.js': outdent`
+                import { defineMessages } from 'react-intl';
+
+                const msg = defineMessages({
+                    b1: 'b.1!',
+                    // b.2 desc
+                    b2: 'b.2!',
+                });
+            `,
+            'bb.js': outdent`
+                import { defineMessages } from 'react-intl';
+
+                const msg = defineMessages({
+                    // b.2 again desc
+                    b2again: 'b.2 again!',
+                });
+            `,
+            'c.js': outdent`
+                import { defineMessages } from 'react-intl';
+
+                const msg = defineMessages({
+                    c1: 'c.1!',
                 });
             `,
         },

--- a/src/lib/riw/app/translate/armdFromSourceFabs.js
+++ b/src/lib/riw/app/translate/armdFromSourceFabs.js
@@ -6,16 +6,17 @@ import pathOr from 'ramda/src/pathOr';
 import compose from 'ramda/src/compose';
 
 import type { AbsolutePath } from '../../../../types';
+import type { Config } from '../../../config';
 import log from '../../../log';
 
 import type { MessageDescriptorsFromFile } from './extract';
 
 
-const outputBabelFromFabs = (fabs: AbsolutePath): babel.BabelFileResult => {
+const outputBabelFromFabs = (fabs: AbsolutePath, config: Config): babel.BabelFileResult => {
+    const plugins = [pluginReactIntl];
+
     try {
-        return transformFileSync(fabs, {
-            plugins: [pluginReactIntl],
-        });
+        return transformFileSync(fabs, { plugins });
 
     } catch (err) {
         log.error(err);

--- a/src/lib/riw/app/translate/armdFromSourceFabs.js
+++ b/src/lib/riw/app/translate/armdFromSourceFabs.js
@@ -2,6 +2,7 @@
 
 import { transformFileSync, type babel } from 'babel-core';
 import pluginReactIntl from 'babel-plugin-react-intl';
+import pluginReactIntlAuto from 'babel-plugin-react-intl-auto';
 import pathOr from 'ramda/src/pathOr';
 import compose from 'ramda/src/compose';
 
@@ -14,6 +15,10 @@ import type { MessageDescriptorsFromFile } from './extract';
 
 const outputBabelFromFabs = (fabs: AbsolutePath, config: Config): babel.BabelFileResult => {
     const plugins = [pluginReactIntl];
+
+    if (config.reactIntlAutoConfig) {
+        plugins.unshift([pluginReactIntlAuto, config.reactIntlAutoConfig]);
+    }
 
     try {
         return transformFileSync(fabs, { plugins });

--- a/src/lib/riw/app/translate/extract.js
+++ b/src/lib/riw/app/translate/extract.js
@@ -14,12 +14,15 @@ import { arfabsInputJSON, arfabsInputSource } from '../../../config-helper';
 import armdFromJSONFabs from './armdFromJSONFabs';
 import armdfromSourceFabs from './armdFromSourceFabs';
 
-export type MessageDescriptorsFromFile = (fabs: AbsolutePath) => MessageDescriptor[];
+export type MessageDescriptorsFromFile = (
+    fabs: AbsolutePath,
+    config: Config,
+) => MessageDescriptor[];
 
 type MDExtractor = (arfabsFromConfig: FilesFromConfig, armdFromFabs: MessageDescriptorsFromFile) =>
     (notify: Notifier) => (config: Config) => MessageDescriptorWithFile[];
 
-const armdExtract: MDExtractor = (arfabsFromConfig, armdFromFabs) => notify => compose(
+const armdExtract: MDExtractor = (arfabsFromConfig, armdFromFabs) => notify => config => compose(
     notify('endExtract'),
     chain(prop('armd')),
     map(compose(
@@ -28,14 +31,14 @@ const armdExtract: MDExtractor = (arfabsFromConfig, armdFromFabs) => notify => c
             fabs,
             armd: map(
                 md => ({ ...md, file: fabs }: MessageDescriptorWithFile),
-                armdFromFabs(fabs),
+                armdFromFabs(fabs, config),
             ),
         }),
         notify('startExtractFile'),
     )),
     notify('startExtract'),
     arfabsFromConfig,
-);
+)(config);
 
 export const armdExtractSource = armdExtract(arfabsInputSource, armdfromSourceFabs);
 export const armdExtractJSON = armdExtract(arfabsInputJSON, armdFromJSONFabs);

--- a/yarn.lock
+++ b/yarn.lock
@@ -587,6 +587,12 @@ babel-plugin-jest-hoist@^22.2.0:
   version "22.2.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.2.0.tgz#bd34f39d652406669713b8c89e23ef25c890b993"
 
+babel-plugin-react-intl-auto@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-react-intl-auto/-/babel-plugin-react-intl-auto-1.0.0.tgz#f959a6512489758bd3cf5dcaa6be0ca374901fad"
+  dependencies:
+    babel-types "^6.26.0"
+
 babel-plugin-react-intl@^2.3.1:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-react-intl/-/babel-plugin-react-intl-2.4.0.tgz#292fca8030603a9e0476973290836aa0c7da17e2"


### PR DESCRIPTION
This pull request builds support for [babel-plugin-react-intl-auto](https://github.com/akameco/babel-plugin-react-intl-auto) into riw.

There's a new riw configuration setting `reactIntlAutoConfig` to configure the plugin. Set this to `false` to disable this new plugin.

The plugin is enabled by default. This shouldn't break any existing users of riw, as `babel-plugin-react-intl-auto` seems to leave full `react-intl` message descriptors alone.

Closes #7.